### PR TITLE
Services autowiring support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/gbprod/elastica-bundle/compare/v1.1.0...HEAD)
 
+ - Added support for auto-wiring default Elasticsearch connection service into Symfony 3.3+
+
 ## [v1.1.0](https://github.com/gbprod/elastica-bundle/compare/v1.0.1...HEAD)
 
  - Symfony 4 compatibility (#20)

--- a/README.md
+++ b/README.md
@@ -94,6 +94,22 @@ You can now use service `elastica.default_client` or `elastica.my_other_client`
 $client = $container->get('elastica.default_client');
 ```
 
+### Services autowiring support
+
+Symfony 3.3 have introduced support for [services autowiring](https://symfony.com/doc/3.3/service_container/3.3-di-changes.html). To be able to autowire Elastica connection into your services you need to setup your [client configuration](#clients) with a name `default`. In a case if you have multiple connections - only `default` connection will be enabled for autowiring because services autowiring is resolved by class names. 
+
+Autowiring support is enabled by default, but if you need to disable it for some reason - you can do it by set `autowire: false` parameter:
+
+```yaml
+# app/config/config.yml
+elastica:
+    autowire: false
+    clients:
+        default:
+            host: 127.0.0.1
+            port: 9200
+```
+
 ## Tests
 
 Clone this repository (or a fork). You should have `php>=5.6` and `composer` installed.

--- a/src/ElasticaBundle/DependencyInjection/Configuration.php
+++ b/src/ElasticaBundle/DependencyInjection/Configuration.php
@@ -4,6 +4,7 @@ namespace GBProd\ElasticaBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * Configuration
@@ -59,6 +60,16 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end()
         ;
+
+        if (class_exists(ContainerBuilder::class)) {
+            $reflection = new \ReflectionClass(ContainerBuilder::class);
+            if ($reflection->hasMethod('autowire')) {
+                $rootNode
+                    ->children()
+                        ->scalarNode('default_client')->defaultNull()->end()
+                    ->end();
+            }
+        }
 
         return $treeBuilder;
     }

--- a/src/ElasticaBundle/DependencyInjection/Configuration.php
+++ b/src/ElasticaBundle/DependencyInjection/Configuration.php
@@ -4,7 +4,6 @@ namespace GBProd\ElasticaBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * Configuration
@@ -15,6 +14,7 @@ class Configuration implements ConfigurationInterface
 {
     /**
      * {@inheritdoc}
+     * @throws \RuntimeException
      */
     public function getConfigTreeBuilder()
     {
@@ -58,18 +58,9 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->booleanNode('autowire')->defaultTrue()->end()
             ->end()
         ;
-
-        if (class_exists(ContainerBuilder::class)) {
-            $reflection = new \ReflectionClass(ContainerBuilder::class);
-            if ($reflection->hasMethod('autowire')) {
-                $rootNode
-                    ->children()
-                        ->scalarNode('default_client')->defaultNull()->end()
-                    ->end();
-            }
-        }
 
         return $treeBuilder;
     }

--- a/src/ElasticaBundle/DependencyInjection/ElasticaExtension.php
+++ b/src/ElasticaBundle/DependencyInjection/ElasticaExtension.php
@@ -7,7 +7,6 @@ use GBProd\ElasticaBundle\Logger\ElasticaLogger;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Reference;
@@ -70,8 +69,6 @@ class ElasticaExtension extends Extension
     /**
      * @param array $config
      * @param ContainerBuilder $container
-     * @throws \Symfony\Component\DependencyInjection\Exception\LogicException
-     * @throws InvalidArgumentException
      */
     private function loadClients(array $config, ContainerBuilder $container)
     {
@@ -84,7 +81,6 @@ class ElasticaExtension extends Extension
      * @param string $clientName
      * @param array $clientConfig
      * @param ContainerBuilder $container
-     * @throws \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
      */
     private function loadClient($clientName, array $clientConfig, ContainerBuilder $container)
     {
@@ -107,8 +103,7 @@ class ElasticaExtension extends Extension
      *
      * @param array $config
      * @param ContainerBuilder $container
-     * @throws \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @throws \Symfony\Component\DependencyInjection\Exception\LogicException
+     * @throws LogicException
      */
     private function setupAutowire(array $config, ContainerBuilder $container)
     {

--- a/src/ElasticaBundle/DependencyInjection/ElasticaExtension.php
+++ b/src/ElasticaBundle/DependencyInjection/ElasticaExtension.php
@@ -125,7 +125,8 @@ class ElasticaExtension extends Extension
             return;
         }
         if ($container->hasDefinition(Client::class)) {
-            throw new LogicException('Default Elasticsearch client autowiring setup is enabled, but Elastica client service is already defined in container');
+            throw new LogicException('Default Elasticsearch client autowiring setup is enabled, ' .
+                'but Elastica client service is already defined in container');
         }
         $container->setAlias(Client::class, $this->createClientId('default'));
     }

--- a/tests/ElasticaBundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/ElasticaBundle/DependencyInjection/ConfigurationTest.php
@@ -5,7 +5,6 @@ namespace Tests\GBProd\ElasticaBundle\DependencyInjection;
 use GBProd\ElasticaBundle\DependencyInjection\Configuration;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Processor;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * Tests for Configuration
@@ -21,32 +20,15 @@ class ConfigurationTest extends TestCase
         $this->configuration = new Configuration();
     }
 
-    /**
-     * @return bool
-     */
-    private function haveAutowiring()
-    {
-        if (!class_exists(ContainerBuilder::class)) {
-            return false;
-        }
-        $reflection = new \ReflectionClass(ContainerBuilder::class);
-        if ($reflection->hasMethod('autowire')) {
-            return true;
-        }
-        return false;
-    }
-
     public function testEmptyConfiguration()
     {
         $processed = $this->process([]);
 
         $expected = [
-            'clients' => [],
-            'logger'  => 'logger',
+            'clients'  => [],
+            'logger'   => 'logger',
+            'autowire' => true,
         ];
-        if ($this->haveAutowiring()) {
-            $expected['default_client'] = null;
-        }
         $this->assertEquals($expected, $processed);
     }
 
@@ -159,24 +141,6 @@ class ConfigurationTest extends TestCase
         $this->assertNull($processed['clients']['default']['connections'][0]['transport']);
         $this->assertNull($processed['clients']['default']['connections'][0]['timeout']);
         $this->assertTrue($processed['clients']['default']['connections'][0]['persistent']);
-    }
-
-    public function testDefaultClientConfigurationOptionIsAvailableInACaseOfAutowiringSupport()
-    {
-        $processed = $this->process([
-            [
-                'clients' => [
-                    'default' => [
-                        'host' => '127.0.0.1',
-                        'port' => '9200',
-                    ]
-                ],
-            ]
-        ]);
-        if ($this->haveAutowiring()) {
-            $this->assertArrayHasKey('default_client', $processed);
-        } else {
-            $this->assertArrayNotHasKey('default_client', $processed);
-        }
+        $this->assertTrue($processed['autowire']);
     }
 }

--- a/tests/ElasticaBundle/DependencyInjection/ElasticaExtensionTest.php
+++ b/tests/ElasticaBundle/DependencyInjection/ElasticaExtensionTest.php
@@ -34,7 +34,6 @@ class ElasticaExtensionTest extends TestCase
     {
         $autowire = false;
         if (class_exists(ContainerBuilder::class)) {
-            /** @noinspection PhpUnhandledExceptionInspection */
             $reflection = new \ReflectionClass(ContainerBuilder::class);
             if ($reflection->hasMethod('autowire')) {
                 $autowire = true;
@@ -164,10 +163,7 @@ class ElasticaExtensionTest extends TestCase
         ];
         $this->extension->load($config, $this->container);
         $this->assertTrue($this->container->has(Client::class));
-        /** @noinspection PhpUnhandledExceptionInspection */
         $this->assertInstanceOf(Client::class, $this->container->get(Client::class));
-        /** @noinspection PhpUnhandledExceptionInspection */
-        /** @noinspection MissingService */
         $this->assertSame($this->container->get(Client::class), $this->container->get('elastica.default_client'));
     }
 

--- a/tests/ElasticaBundle/Logger/ElasticaLoggerTest.php
+++ b/tests/ElasticaBundle/Logger/ElasticaLoggerTest.php
@@ -60,6 +60,7 @@ class ElasticaLoggerTest extends TestCase
 
     /**
      * @dataProvider getLevels
+     * @doesNotPerformAssertions
      */
     public function testNotDelegateLogsLevels($level)
     {
@@ -109,7 +110,10 @@ class ElasticaLoggerTest extends TestCase
         $this->assertEquals(0, $elasticaLogger->getNbQueries());
     }
 
-     public function testNotDelegateLog()
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testNotDelegateLog()
     {
         $testedInstance = new ElasticaLogger(null);
 


### PR DESCRIPTION
Added support for providing alias for default Elasticsearch client to allow services autowiring in Symfony 3.3+. Fixes #24.

Tests coverage reduces a bit and there is several skipped tests are available for versions of Symfony lower then 3.3 because autowiring by itself is introduced only in 3.3.